### PR TITLE
Correctly set private and temporary file path

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -74,12 +74,15 @@ if (getenv("PLATFORM_RELATIONSHIPS")) {
 
   $routes = json_decode(base64_decode($_ENV['PLATFORM_ROUTES']), TRUE);
 
-  if (!isset($conf['file_private_path'])) {
-    if(!$application_home = getenv('PLATFORM_APP_DIR')) {
-      $application_home = '/app';
-    }
-    $conf['file_private_path'] = $application_home . '/private';
-    $conf['file_temporary_path'] = $application_home . '/tmp';
+  // Set the private and temporay paths.
+  if(!$application_home = getenv('PLATFORM_APP_DIR')) {
+    $application_home = '/app';
+  }
+  if (!isset($settings['file_private_path'])) {
+    $settings['file_private_path'] = $application_home . '/private';
+  }
+  if (!isset($config['system.file']['path']['temporary'])) {
+    $config['system.file']['path']['temporary'] = $application_home . '/tmp';
   }
 
   $variables = json_decode(base64_decode($_ENV['PLATFORM_VARIABLES']), TRUE);


### PR DESCRIPTION
I think the check for the application dir might not be needed anymore, AFAIK that's now also set on standard as we requested that a while ago.

Should also be  merged into the 8.x branch.