### PR TITLE
Surely the drupal root is "web" in this case, not "public"?

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -32,7 +32,7 @@ web:
         "/":
             # The folder to serve static assets for this location from.
             # (Relative to the application root.)
-            root: "public"
+            root: "web"
 
             # How long to allow static assets from this location to be cached.
             # (Can be a time or -1 for no caching. Times can be suffixed with


### PR DESCRIPTION
because the folder structure of drupal-composer/drupal-project is slightly different from the platform.sh norms, I believe that the location of the drupal root in the config needs changing.

Unless I have missed some really subtle platform.sh point?