### PR TITLE
D7: Update Drupal core to version 7.44

### DIFF
--- a/project.make
+++ b/project.make
@@ -3,7 +3,7 @@ core = 7.x
 
 ; Drupal core.
 projects[drupal][type] = core
-projects[drupal][version] = 7.43
+projects[drupal][version] = 7.44
 projects[drupal][patch][] = "https://drupal.org/files/issues/install-redirect-on-empty-database-728702-36.patch"
 
 ; Drush make allows a default sub directory for all contributed projects.


### PR DESCRIPTION
Release notes: https://www.drupal.org/project/drupal/releases/7.44